### PR TITLE
onUrisReady has been moved from VIE.js to extender.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -72,6 +72,7 @@ function(module, VIE, Logger, tracker, userParams, UserData, SocialSemanticServi
     //v.namespaces.base(namespace);
 
     extender.syncByVIE(v);
+    extender.addOnUrisReady(v);
     //extender.autoResolveReferences(v);
 
     AppData.init(v);

--- a/js/extender.js
+++ b/js/extender.js
@@ -1,4 +1,4 @@
-define(['logger', 'underscore', 'voc'], function(Logger, _, Voc){
+define(['logger', 'underscore', 'voc', 'vie'], function(Logger, _, Voc, VIE){
     AppLog = Logger.get('App');
     AddLog = Logger.get('Add');
     return {
@@ -93,6 +93,58 @@ define(['logger', 'underscore', 'voc'], function(Logger, _, Voc){
                         break;
                 }
 
+            };
+        },
+        /**
+         * Waits for the given blank node references in arguments to turn into URIs.
+         * Then executes the last argument as a callback with the adapted arguments as parameter.
+         */
+        addOnUrisReady : function(v) {
+            v.onUrisReady = function() {
+                var that = this,
+                    wait = false,
+                    args = _.initial(arguments),
+                    callback = _.last(arguments),
+                    entity;
+                _.each(args, function(arg) {
+                    if( wait || !arg ) return;
+                    wait = VIE.Util.isBlankNode(arg);
+                });
+                if( !wait ) {
+                    callback.apply(this, args);
+                    return;
+                }
+
+                // there is some blank node reference:
+                var j, waitFor = 0;
+                _.each(args, function(arg) {
+                    if( !arg ) return;
+
+                    if( VIE.Util.isBlankNode(arg) ) {
+                        entity = that.entities.get(arg);
+                        if( !entity ) return;
+
+                        var func = function(ent, value) {
+                            // replace argument by new URI
+                            for( j = 0; j < args.length; j++ ) {
+                                if( args[j] === arg ) {
+                                    args[j] = that.namespaces.uri(value);
+                                }
+                            };
+                            if( --waitFor == 0 ) {
+                                callback.apply(that, args);
+                            }
+                            // turn off listener
+                            entity.off('change:'+entity.idAttribute, func);
+                        };
+                        // add listener
+                        entity.on('change:' + entity.idAttribute, func);
+                        waitFor++;
+                        if( !VIE.Util.isBlankNode(entity.getSubject()) )  {
+                            func(entity, entity.getSubject());
+                        }
+                    }
+                });
             };
         },
         autoResolveReferences: function(v) {

--- a/lib/VIE/vie.js
+++ b/lib/VIE/vie.js
@@ -430,57 +430,6 @@ VIE.prototype.getTypedEntityClass = function (type) {
 };
 VIE.prototype.typeEntityClasses = {};
 
-/**
- * Waits for the given blank node references in arguments to turn into URIs.
- * Then executes the last argument as a callback with the adapted arguments as parameter.
- */
-VIE.prototype.onUrisReady = function() {
-    var that = this,
-        wait = false,
-        args = _.initial(arguments),
-        callback = _.last(arguments),
-        entity;
-    _.each(args, function(arg) {
-        if( wait || !arg ) return;
-        wait = VIE.Util.isBlankNode(arg);
-    });
-    if( !wait ) {
-        callback.apply(this, args);
-        return;
-    }
-
-    // there is some blank node reference:
-    var j, waitFor = 0;
-    _.each(args, function(arg) {
-        if( !arg ) return;
-
-        if( VIE.Util.isBlankNode(arg) ) {
-            entity = that.entities.get(arg);
-            if( !entity ) return;
-
-            var func = function(ent, value) {
-                // replace argument by new URI
-                for( j = 0; j < args.length; j++ ) {
-                    if( args[j] === arg ) {
-                        args[j] = that.namespaces.uri(value);
-                    }
-                };
-                if( --waitFor == 0 ) {
-                    callback.apply(that, args);
-                }
-                // turn off listener
-                entity.off('change:'+entity.idAttribute, func);
-            };
-            // add listener
-            entity.on('change:' + entity.idAttribute, func);
-            waitFor++;
-            if( !VIE.Util.isBlankNode(entity.getSubject()) )  {
-                func(entity, entity.getSubject());
-            }
-        }
-    });
-};
-
 // ## Running VIE on Node.js
 //
 // When VIE is running under Node.js we can use the CommonJS


### PR DESCRIPTION
As a result of a hack onUrisReady was still present in vie.js without being pushed to the VIE repo. Since onUrisReady is an extension by BnP to VIE, it has now been moved to extender.js.
