### PR TITLE
LL-1233 #resolve Added timeouts to limit the amount of calls.

### DIFF
--- a/js/data/timeline/TimelineData.js
+++ b/js/data/timeline/TimelineData.js
@@ -1,5 +1,7 @@
 define(['logger', 'voc', 'underscore', 'data/Data', 'data/episode/UserData' ], function(Logger, Voc, _, Data, UserData){
     var m = Object.create(Data);
+    var fetchDataTimer = null;
+    var setStateTimer = null;
     m.init = function(vie) {
         this.LOG.debug("initialize TimelineData");
         this.vie = vie;
@@ -20,7 +22,14 @@ define(['logger', 'voc', 'underscore', 'data/Data', 'data/episode/UserData' ], f
             // TODO resolve this hack: only fire on start change to avoid double execution
             model.on('change:' + this.vie.namespaces.uri(Voc.start),
                 function(model, value, options){
-                    UserData.fetchRange(user, value, model.get(Voc.end));
+                    if (fetchDataTimer) {
+                        clearTimeout(fetchDataTimer);
+                    }
+
+                    fetchDataTimer = setTimeout(function() {
+                        fetchDataTimer = null;
+                        UserData.fetchRange(user, value, model.get(Voc.end));
+                    }, 250);
                 }
             );
             model.sync = this.sync;
@@ -32,7 +41,14 @@ define(['logger', 'voc', 'underscore', 'data/Data', 'data/episode/UserData' ], f
         switch(method) {
             case 'create':
             case 'update':
-                m.saveTimelineState(model, options);
+                if (setStateTimer) {
+                        clearTimeout(setStateTimer);
+                    }
+
+                    setStateTimer = setTimeout(function() {
+                        setStateTimer = null;
+                        m.saveTimelineState(model, options);
+                    }, 250);
                 break;
             case 'read':
                 m.fetchTimelineState(model, options);


### PR DESCRIPTION
The timeouts will only fire when user has stopped scrolling/zooming and
it is safe to update the state. Current timeout time is set to 250ms
that seems to be a good enough period not to issue too many unnecessary
calls.